### PR TITLE
Rust naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,16 +63,16 @@ Now, we're getting to the interesting part: **the tests!** The `add` function is
 #include <add.h>
 
 void test_add(CFTEST) {
-    assertIntEqual(add(1, 2), 3);
+    assert_int_equal(add(1, 2), 3);
 }
 
 int main(void) {
-    cfInit();
+    cf_init();
 
-    cfTest(test_add);
+    cf_test(test_add);
 
-    cfPrintCallTree();
-    return cfReturnCode();
+    cf_print_call_tree();
+    return cf_return_code();
 }
 ```
 

--- a/cf.py
+++ b/cf.py
@@ -137,7 +137,7 @@ def makefile_content(name: str, obj_list, sdl: bool, lib: bool):
     )
     return (
         warning
-        + f"CONFER_PATH ?= ${defaults.confer_path}\n"
+        + f"CONFER_PATH ?= {defaults.confer_path}\n"
         + f"""CC = gcc\n.PHONY : clean\n
 OBJ_FILES = {' '.join(map(o_file, obj_list))}
 TARGETS = {'' if lib else f'bin/{name}'} $(OBJ_FILES)\n

--- a/cf.py
+++ b/cf.py
@@ -42,16 +42,16 @@ int main(void) {
 #include <add.h>
 
 void test_add(CFTEST) { // make it a test
-  assertIntEqual(add(1, 2), 3);
+  assert_int_equal(add(1, 2), 3);
 }
 
 int main(void) {
-    cfInit();
+    cf_init();
 
-    cfTest(test_add); // call subtests
+    cf_test(test_add); // call subtests
 
-    cfPrintCallTree();
-    return cfReturnCode();
+    cf_print_call_tree();
+    return cf_return_code();
 }
 """,
 )

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,14 +25,14 @@ Then, after calling the initialization function, you will be able to write your 
 
 ```c
 void main(void) {
-  cfInit(); // nothing more needed
-  cfTest(test_my_function); // call subtests
-  cfPrintCallTree(); // show the results
+  cf_init(); // nothing more needed
+  cf_test(test_my_function); // call subtests
+  cf_print_call_tree(); // show the results
 }
 
 void test_my_function(CFTEST) { // make it a test
-  assertIntEqual(my_function(0), 1);
-  assertIntGreater(my_function(2), 7);
+  assert_int_equal(my_function(0), 1);
+  assert_int_greater(my_function(2), 7);
 }
 ```
 

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -5,22 +5,22 @@ title: Assertions
 Assertions
 ==========
 
-Confer comes with more than 20 built-in assertions. You can call them from any `CFTEST` or from your `main` function. Here is an example with `assertIntEqual`:
+Confer comes with more than 20 built-in assertions. You can call them from any `CFTEST` or from your `main` function. Here is an example with `assert_int_equal`:
 
 ```c
 void test_plus(CFTEST) {
-    assertIntEqual(2 + 3, 5);
+    assert_int_equal(2 + 3, 5);
 }
 ```
 
 {% info Calling subtests %}
-To run tests in `test_plus`, call it with `cfTest(test_plus);` from any `CFTEST` or from your `main` function.
+To run tests in `test_plus`, call it with `cf_test(test_plus);` from any `CFTEST` or from your `main` function.
 {% end %}
 
 Assertions return `true` if they pass, `false` if they fail. This return value can be used in conditions to make more tests:
 ```c
-if (assertNotNull(my_car_pointer)) {
-    assertTrue(is_red(*my_car_pointer));
+if (assert_not_null(my_car_pointer)) {
+    assert_true(is_red(*my_car_pointer));
 }
 ```
 This prevents errors like null dereferences or semgentation faults.
@@ -37,11 +37,11 @@ This prevents errors like null dereferences or semgentation faults.
 ### Booleans
 
 ```c
-int assertTrue(bool b);
+int assert_true(bool b);
 ```
 
 ```c
-int assertFalse(bool b);
+int assert_false(bool b);
 ```
 
 Test that `b` is true (or false).
@@ -49,21 +49,21 @@ Test that `b` is true (or false).
 ### Pointers
 
 ```c
-int assertNull(void *p);
+int assert_null(void *p);
 ```
 
 ```c
-int assertNotNull(void *p);
+int assert_not_null(void *p);
 ```
 
 Test that `p` is (or is not) `NULL`.
 
 ```c
-int assertPointerEqual(const void *p1, const void *p2);
+int assert_pointer_equal(const void *p1, const void *p2);
 ```
 
 ```c
-int assertPointerNotEqual(const void *p1, const void *p2);
+int assert_pointer_not_equal(const void *p1, const void *p2);
 ```
 
 Test that `p1` and `p2` are (or are not) equal.
@@ -71,69 +71,69 @@ Test that `p1` and `p2` are (or are not) equal.
 ### Integers
 
 ```c
-int assertZero(int x);
+int assert_zero(int x);
 ```
 
 ```c
-int assertNonZero(int x);
+int assert_non_zero(int x);
 ```
 
 Test that `x` is (or is not) equal to `0`.
 
 ```c
-int assertIntEqual(int x, int y);
+int assert_int_equal(int x, int y);
 ```
 
 ```c
-int assertIntNotEqual(int x, int y);
+int assert_int_not_equal(int x, int y);
 ```
 
 Test that `x` and `y` are (or are not) equal.
 
 ```c
-int assertIntGe(int x, int y);
+int assert_int_ge(int x, int y);
 ```
 
 Test that `x` is greater than or equal to `y` (passes if `x >= y`).
 
 ```c
-int assertIntLe(int x, int y);
+int assert_int_le(int x, int y);
 ```
 
 Test that `x` is less than or equal to `y` (passes if `x <= y`).
 
 ```c
-int assertIntGreater(int x, int y);
+int assert_int_greater(int x, int y);
 ```
 
 Test that `x` is greater than `y` (passes if `x > y`).
 
 ```c
-int assertIntLess(int x, int y);
+int assert_int_less(int x, int y);
 ```
 
 Test that `x` is less than `y` (passes if `x < y`).
 
 ```c
-int assertIntNonNegative(int x);
+int assert_int_non_negative(int x);
 ```
 
 Test that `x` is non-negative; that is, greater than or equal to `0` (passes if `x >= 0`).
 
 ```c
-int assertIntNonPositive(int x);
+int assert_int_non_positive(int x);
 ```
 
 Test that `x` is non-positive; that is, less than or equal to `0` (passes if `x <= 0`).
 
 ```c
-int assertIntPositive(int x);
+int assert_int_positive(int x);
 ```
 
 Test that `x` is positive; that is, greater than `0` (passes if `x > 0`).
 
 ```c
-int assertIntNegative(int x);
+int assert_int_negative(int x);
 ```
 
 Test that `x` is negative; that is, less than `0` (passes if `x < 0`).
@@ -141,21 +141,21 @@ Test that `x` is negative; that is, less than `0` (passes if `x < 0`).
 ### Characters & bytes
 
 ```c
-int assertCharEqual(char c1, char c2);
+int assert_char_equal(char c1, char c2);
 ```
 
 ```c
-int assertCharNotEqual(char c1, char c2);
+int assert_char_not_equal(char c1, char c2);
 ```
 
 Test that `c1` and `c2` are (or are not) equal.
 
 ```c
-int assertByteEqual(unsigned char b1, unsigned char b2);
+int assert_byte_equal(unsigned char b1, unsigned char b2);
 ```
 
 ```c
-int assertByteNotEqual(unsigned char b1, unsigned char b2);
+int assert_byte_not_equal(unsigned char b1, unsigned char b2);
 ```
 
 Test that `b1` and `b2` are (or are not) equal.
@@ -163,13 +163,13 @@ Test that `b1` and `b2` are (or are not) equal.
 ### Strings
 
 ```c
-int assertStringEqual(const char *s1, const char *s2);
+int assert_string_equal(const char *s1, const char *s2);
 ```
 
 Test that `s1` and `s2` are equal (passes if `strcmp(s1, s2) == 0`).
 
 ```c
-int assertStringNotEqual(const char *s1, const char *s2);
+int assert_string_not_equal(const char *s1, const char *s2);
 ```
 
 Test that `s1` and `s2` are not equal (passes if `strcmp(s1, s2) != 0`).
@@ -182,25 +182,25 @@ Chaining assertions is used to pass parameters to an existing check function. Le
 
 ```c
 // Bad code
-assertTrue(is_zero(x));
+assert_true(is_zero(x));
 ```
 
 This is a bad coding practice, because if the check fails we have no way to get back the value of x, and log it for example. Chained assertions were designed to solve this problem. To work with chained assertions we use two functions
 
 ```c
-int assertChain(f, ...)
-int assertChainNot(f, ...)
+int assert_chain(f, ...)
+int assert_chain_not(f, ...)
 ```
 
 They apply the arguments in `...` to the function `f` that returns a `bool`, providing more insights than the previous method if the test fails. The previous code would be replaced by
 
 ```c
-assertChain(is_zero, x);
+assert_chain(is_zero, x);
 ```
 
 Chained assertions work with multiple arguments too, so checking if two `rational` numbers `x` and `y` are equal would be fairly simple using a `are_equal` function
 ```c
-assertChain(are_equal, x, y);
+assert_chain(are_equal, x, y);
 ```
 
 ### Custom assertions

--- a/docs/example.md
+++ b/docs/example.md
@@ -80,13 +80,13 @@ Now our `test/test.c` file looks like this:
 #include <operations.h>
 
 int main(void) {
-    cfInit();
-    cfPrintCallTree();
+    cf_tnit();
+    cf_print_call_tree();
     return 0;
 }
 ```
 
-Now we can write our test: from `main`, we will call the subtest `test_operations`, that will itself call `test_plus`. Calling a subtest from a function is easy, we just have to use the `cfTest` function. Once this is done, our `test/test.c` file will look like this:
+Now we can write our test: from `main`, we will call the subtest `test_operations`, that will itself call `test_plus`. Calling a subtest from a function is easy, we just have to use the `cf_test` function. Once this is done, our `test/test.c` file will look like this:
 ```c
 #include <confer.h>
 #include <operations.h>
@@ -95,13 +95,13 @@ void test_operations(CFTEST);
 void test_plus(CFTEST);
 
 int main(void) {
-    cfInit();
-    cfTest(test_operations);
-    cfPrintCallTree();
+    cf_init();
+    cf_test(test_operations);
+    cf_print_call_tree();
     return 0;
 }
 
-void test_operations(CFTEST) { cfTest(test_plus); }
+void test_operations(CFTEST) { cf_test(test_plus); }
 
 void test_plus(CFTEST) {}
 ```
@@ -113,8 +113,8 @@ For a better readability, place the functions' signature on top of the file.
 Finally, we can test our `plus` function using Confer's built-in assertions:
 ```c
 void test_plus(CFTEST) {
-    assertIntEqual(plus(1, 2), 3);
-    assertIntNotEqual(plus(1, -2), 0);
+    assert_int_equal(plus(1, 2), 3);
+    assert_int_not_equal(plus(1, -2), 0);
 }
 ```
 

--- a/examples/calc/test/test.c
+++ b/examples/calc/test/test.c
@@ -5,15 +5,15 @@ void test_operations(CFTEST);
 void test_plus(CFTEST);
 
 int main(void) {
-    cfInit();
-    cfTest(test_operations);
-    cfPrintCallTree();
+    cf_init();
+    cf_test(test_operations);
+    cf_print_call_tree();
     return 0;
 }
 
-void test_operations(CFTEST) { cfTest(test_plus); }
+void test_operations(CFTEST) { cf_test(test_plus); }
 
 void test_plus(CFTEST) {
-    assertIntEqual(plus(1, 2), 3);
-    assertIntNotEqual(plus(1, -2), 0);
+    assert_int_equal(plus(1, 2), 3);
+    assert_int_not_equal(plus(1, -2), 0);
 }

--- a/include/assertions.h
+++ b/include/assertions.h
@@ -3,74 +3,74 @@
 #include <stdbool.h>
 #include "build.h"
 
-#define assertIsNull assertNull
-#define assertIsNotNull assertNotNull
+#define assert_is_null assert_null
+#define assertIsNotNull assert_not_null
 #define _ASSERT_ARGS struct cfScope *scope, unsigned int line, const char *file
 #define ASSERT_ARGS self, __LINE__, __FILE__
 
-int _assertTrue(bool b, _ASSERT_ARGS);
-int _assertFalse(bool b, _ASSERT_ARGS);
+int _assert_true(bool b, _ASSERT_ARGS);
+int _assert_false(bool b, _ASSERT_ARGS);
 
-int _assertNull(void *p, _ASSERT_ARGS);
-int _assertNotNull(void *p, _ASSERT_ARGS);
-int _assertPointerEqual(const void *p1, const void *p2, _ASSERT_ARGS);
-int _assertPointerNotEqual(const void *p1, const void *p2, _ASSERT_ARGS);
+int _assert_null(void *p, _ASSERT_ARGS);
+int _assert_not_null(void *p, _ASSERT_ARGS);
+int _assert_pointer_equal(const void *p1, const void *p2, _ASSERT_ARGS);
+int _assert_pointer_not_equal(const void *p1, const void *p2, _ASSERT_ARGS);
 
-int _assertZero(int x, _ASSERT_ARGS);
-int _assertNonZero(int x, _ASSERT_ARGS);
-int _assertIntEqual(int x, int y, _ASSERT_ARGS);
-int _assertIntNotEqual(int x, int y, _ASSERT_ARGS);
+int _assert_zero(int x, _ASSERT_ARGS);
+int _assert_non_zero(int x, _ASSERT_ARGS);
+int _assert_int_equal(int x, int y, _ASSERT_ARGS);
+int _assert_int_not_equal(int x, int y, _ASSERT_ARGS);
 
-int _assertIntGe(int x, int y, _ASSERT_ARGS);
-int _assertIntLe(int x, int y, _ASSERT_ARGS);
-int _assertIntGreater(int x, int y, _ASSERT_ARGS);
-int _assertIntLess(int x, int y, _ASSERT_ARGS);
-int _assertIntNonNegative(int x, _ASSERT_ARGS);
-int _assertIntNonPositive(int x, _ASSERT_ARGS);
-int _assertIntPositive(int x, _ASSERT_ARGS);
-int _assertIntNegative(int x, _ASSERT_ARGS);
+int _assert_int_ge(int x, int y, _ASSERT_ARGS);
+int _assert_int_le(int x, int y, _ASSERT_ARGS);
+int _assert_int_greater(int x, int y, _ASSERT_ARGS);
+int _assert_int_less(int x, int y, _ASSERT_ARGS);
+int _assert_int_non_negative(int x, _ASSERT_ARGS);
+int _assert_int_non_positive(int x, _ASSERT_ARGS);
+int _assert_int_positive(int x, _ASSERT_ARGS);
+int _assert_int_negative(int x, _ASSERT_ARGS);
 
-int _assertCharEqual(char c1, char c2, _ASSERT_ARGS);
-int _assertCharNotEqual(char c1, char c2, _ASSERT_ARGS);
+int _assert_char_equal(char c1, char c2, _ASSERT_ARGS);
+int _assert_char_not_equal(char c1, char c2, _ASSERT_ARGS);
 
-int _assertByteEqual(unsigned char b1, unsigned char b2, _ASSERT_ARGS);
-int _assertByteNotEqual(unsigned char b1, unsigned char b2, _ASSERT_ARGS);
+int _assert_byte_equal(unsigned char b1, unsigned char b2, _ASSERT_ARGS);
+int _assert_byte_not_equal(unsigned char b1, unsigned char b2, _ASSERT_ARGS);
 
-int _assertStringEqual(const char *s1, const char *s2, _ASSERT_ARGS);
-int _assertStringNotEqual(const char *s1, const char *s2, _ASSERT_ARGS);
+int _assert_string_equal(const char *s1, const char *s2, _ASSERT_ARGS);
+int _assert_string_not_equal(const char *s1, const char *s2, _ASSERT_ARGS);
 
-int _assertTrueChain(bool b, _ASSERT_ARGS);
-int _assertFalseChain(bool b, _ASSERT_ARGS);
+int _assert_true_chain(bool b, _ASSERT_ARGS);
+int _assert_false_chain(bool b, _ASSERT_ARGS);
 
-#define assertTrue(b) _assertTrue(b, ASSERT_ARGS)
-#define assertFalse(b) _assertFalse(b, ASSERT_ARGS)
+#define assert_true(b) _assert_true(b, ASSERT_ARGS)
+#define assert_false(b) _assert_false(b, ASSERT_ARGS)
 
-#define assertNull(p) _assertNull(p, ASSERT_ARGS)
-#define assertNotNull(p) _assertNotNull(p, ASSERT_ARGS)
-#define assertPointerEqual(p1, p2) _assertPointerEqual(p1, p2, ASSERT_ARGS)
-#define assertPointerNotEqual(p1, p2) _assertPointerNotEqual(p1, p2, ASSERT_ARGS)
+#define assert_null(p) _assert_null(p, ASSERT_ARGS)
+#define assert_not_null(p) _assert_not_null(p, ASSERT_ARGS)
+#define assert_pointer_equal(p1, p2) _assert_pointer_equal(p1, p2, ASSERT_ARGS)
+#define assert_pointer_not_equal(p1, p2) _assert_pointer_not_equal(p1, p2, ASSERT_ARGS)
 
-#define assertZero(x) _assertZero(x, ASSERT_ARGS)
-#define assertNonZero(x) _assertNonZero(x, ASSERT_ARGS)
-#define assertIntEqual(x, y) _assertIntEqual(x, y, ASSERT_ARGS)
-#define assertIntNotEqual(x, y) _assertIntNotEqual(x, y, ASSERT_ARGS)
+#define assert_zero(x) _assert_zero(x, ASSERT_ARGS)
+#define assert_non_zero(x) _assert_non_zero(x, ASSERT_ARGS)
+#define assert_int_equal(x, y) _assert_int_equal(x, y, ASSERT_ARGS)
+#define assert_int_not_equal(x, y) _assert_int_not_equal(x, y, ASSERT_ARGS)
 
-#define assertIntGe(x, y) _assertIntGe(x, y, ASSERT_ARGS)
-#define assertIntLe(x, y) _assertIntLe(x, y, ASSERT_ARGS)
-#define assertIntGreater(x, y) _assertIntGreater(x, y, ASSERT_ARGS)
-#define assertIntLess(x, y) _assertIntLess(x, y, ASSERT_ARGS)
-#define assertIntNonNegative(x) _assertIntNonNegative(x, ASSERT_ARGS)
-#define assertIntNonPositive(x) _assertIntNonPositive(x, ASSERT_ARGS)
-#define assertIntPositive(x) _assertIntPositive(x, ASSERT_ARGS)
-#define assertIntNegative(x) _assertIntNegative(x, ASSERT_ARGS)
+#define assert_int_ge(x, y) _assert_int_ge(x, y, ASSERT_ARGS)
+#define assert_int_le(x, y) _assert_int_le(x, y, ASSERT_ARGS)
+#define assert_int_greater(x, y) _assert_int_greater(x, y, ASSERT_ARGS)
+#define assert_int_less(x, y) _assert_int_less(x, y, ASSERT_ARGS)
+#define assert_int_non_negative(x) _assert_int_non_negative(x, ASSERT_ARGS)
+#define assert_int_non_positive(x) _assert_int_non_positive(x, ASSERT_ARGS)
+#define assert_int_positive(x) _assert_int_positive(x, ASSERT_ARGS)
+#define assert_int_negative(x) _assert_int_negative(x, ASSERT_ARGS)
 
-#define assertCharEqual(x, y) _assertCharEqual(x, y, ASSERT_ARGS)
-#define assertCharNotEqual(x, y) _assertCharNotEqual(x, y, ASSERT_ARGS)
+#define assert_char_equal(x, y) _assert_char_equal(x, y, ASSERT_ARGS)
+#define assert_char_not_equal(x, y) _assert_char_not_equal(x, y, ASSERT_ARGS)
 
-#define assertStringEqual(s1, s2) _assertStringEqual(s1, s2, ASSERT_ARGS)
-#define assertStringNotEqual(p1, p2) _assertStringNotEqual(p1, p2, ASSERT_ARGS)
+#define assert_string_equal(s1, s2) _assert_string_equal(s1, s2, ASSERT_ARGS)
+#define assert_string_not_equal(p1, p2) _assert_string_not_equal(p1, p2, ASSERT_ARGS)
 
-#define assertChain(f, ...) _assertTrueChain(f(__VA_ARGS__), ASSERT_ARGS)
-#define assertChainNot(f, ...) _assertFalseChain(f(__VA_ARGS__), ASSERT_ARGS)
+#define assert_chain(f, ...) _assert_true_chain(f(__VA_ARGS__), ASSERT_ARGS)
+#define assert_chain_not(f, ...) _assert_false_chain(f(__VA_ARGS__), ASSERT_ARGS)
 
 #endif

--- a/include/build.h
+++ b/include/build.h
@@ -17,15 +17,15 @@ struct cfScope
     struct cfTestsCount assertions;
 };
 
-#define initScope(s) _initScope(&s, #s)
+#define init_scope(s) _init_scope(&s, #s)
 
-#define initRootScope()          \
+#define init_root_scope()          \
     struct cfScope node_main;    \
-    initScope(node_main);        \
+    init_scope(node_main);        \
     static struct cfScope *self; \
     self = &node_main
 
-void _initScope(struct cfScope *s, const char *name);
-void _cfAddChild(struct cfScope *parent, struct cfScope *child);
+void _init_scope(struct cfScope *s, const char *name);
+void _cf_add_child(struct cfScope *parent, struct cfScope *child);
 
 #endif

--- a/include/children.h
+++ b/include/children.h
@@ -5,16 +5,16 @@
 
 #include <stdbool.h>
 #include "build.h"
-bool isLastChild(struct cfScope *s);
-int getChildIndex(struct cfScope *s);
-struct cfScope *getParent(struct cfScope *s, unsigned int depth);
+bool is_last_child(struct cfScope *s);
+int get_child_index(struct cfScope *s);
+struct cfScope *get_parent(struct cfScope *s, unsigned int depth);
 
-bool hasChildrenWithErrors(struct cfScope *scope);
-unsigned int countChildren(struct cfScope *scope);
-unsigned int countChildrenPassed(struct cfScope *scope);
-unsigned int countChildrenFailed(struct cfScope *scope);
+bool has_children_with_errors(struct cfScope *scope);
+unsigned int count_children(struct cfScope *scope);
+unsigned int count_children_passed(struct cfScope *scope);
+unsigned int count_children_failed(struct cfScope *scope);
 
-unsigned int countAssertionsPassed(struct cfScope *scope);
-unsigned int countAssertionsFailed(struct cfScope *scope);
+unsigned int count_assertions_passed(struct cfScope *scope);
+unsigned int count_assertions_failed(struct cfScope *scope);
 
 #endif

--- a/include/confer.h
+++ b/include/confer.h
@@ -5,10 +5,10 @@
 #include "build.h"
 #include "print.h"
 
-#define cfInit init_root_scope
+#define cf_init init_root_scope
 
 #define CFTEST struct cfScope *self
-#define cfTest(f)                   \
+#define cf_test(f)                   \
     static struct cfScope node_##f; \
     init_scope(node_##f);            \
     _cf_add_child(self, &node_##f);   \

--- a/include/confer.h
+++ b/include/confer.h
@@ -5,13 +5,13 @@
 #include "build.h"
 #include "print.h"
 
-#define cfInit initRootScope
+#define cfInit init_root_scope
 
 #define CFTEST struct cfScope *self
 #define cfTest(f)                   \
     static struct cfScope node_##f; \
-    initScope(node_##f);            \
-    _cfAddChild(self, &node_##f);   \
+    init_scope(node_##f);            \
+    _cf_add_child(self, &node_##f);   \
     f(&node_##f)
 
 #endif

--- a/include/print.h
+++ b/include/print.h
@@ -3,14 +3,14 @@
 
 #include "build.h"
 
-#define cfPrintCallTree() printTree(&node_main);
-#define cfPrintResults() _cfPrintResults(self)
-#define cfReturnCode() _cfReturnCode(&node_main)
+#define cf_print_call_tree() print_tree(&node_main);
+#define cf_print_results() _cf_print_results(self)
+#define cf_return_code() _cf_return_code(&node_main)
 
-void printTree(struct cfScope *root);
-void printScope(struct cfScope *s, const int depth);
-int _cfPrintResults(struct cfScope *root);
-void _cfPrintAssertionFail(const char *file, const char *assertionType, const unsigned int line, const struct cfScope *scope);
-int _cfReturnCode(struct cfScope *root);
+void print_tree(struct cfScope *root);
+void print_scope(struct cfScope *s, const int depth);
+int _cf_print_results(struct cfScope *root);
+void _cf_print_assertion_fail(const char *file, const char *assertionType, const unsigned int line, const struct cfScope *scope);
+int _cf_return_code(struct cfScope *root);
 
 #endif

--- a/src/assertions.c
+++ b/src/assertions.c
@@ -11,7 +11,7 @@
 #define CF_ASSERTIONS_CONTEXT_ARGS struct cfScope *scope, unsigned int line, const char *file
 #define CF_ASSERTIONS_CONTEXT scope, line, file
 
-static char *boolToString(bool b);
+static char *bool_to_string(bool b);
 
 #define _assert(condition, CF_ASSERTIONS_CONTEXT, format, ...) \
     if (condition)                                             \
@@ -22,117 +22,117 @@ static char *boolToString(bool b);
     else                                                       \
     {                                                          \
         ++scope->assertions.failed;                            \
-        _cfPrintAssertionFail(file, __func__, line, scope);    \
+        _cf_print_assertion_fail(file, __func__, line, scope);    \
         printf(format __VA_OPT__(, ) __VA_ARGS__);             \
         putc('\n', stdout);                                    \
         return ASSERTION_FAILED;                               \
     }
 
-int _assertNull(void *p, CF_ASSERTIONS_CONTEXT_ARGS)
+int _assert_null(void *p, CF_ASSERTIONS_CONTEXT_ARGS)
 {
     _assert(p == NULL, CF_ASSERTIONS_CONTEXT, "(%p): is not null", p);
 }
-int _assertNotNull(void *p, CF_ASSERTIONS_CONTEXT_ARGS)
+int _assert_not_null(void *p, CF_ASSERTIONS_CONTEXT_ARGS)
 {
     _assert(p != NULL, CF_ASSERTIONS_CONTEXT, "(NULL): is null");
 }
-int _assertPointerEqual(const void *p1, const void *p2, CF_ASSERTIONS_CONTEXT_ARGS)
+int _assert_pointer_equal(const void *p1, const void *p2, CF_ASSERTIONS_CONTEXT_ARGS)
 {
     _assert(p1 == p2, CF_ASSERTIONS_CONTEXT, "(%p, %p): not the same pointer", p1, p2);
 }
-int _assertPointerNotEqual(const void *p1, const void *p2, CF_ASSERTIONS_CONTEXT_ARGS)
+int _assert_pointer_not_equal(const void *p1, const void *p2, CF_ASSERTIONS_CONTEXT_ARGS)
 {
     _assert(p1 != p2, CF_ASSERTIONS_CONTEXT, "(%p, %p): the same pointer", p1, p2);
 }
 
-int _assertTrue(bool b, CF_ASSERTIONS_CONTEXT_ARGS)
+int _assert_true(bool b, CF_ASSERTIONS_CONTEXT_ARGS)
 {
-    _assert(b == true, CF_ASSERTIONS_CONTEXT, "(%s): is not true", boolToString(b));
+    _assert(b == true, CF_ASSERTIONS_CONTEXT, "(%s): is not true", bool_to_string(b));
 }
-int _assertFalse(bool b, CF_ASSERTIONS_CONTEXT_ARGS)
+int _assert_false(bool b, CF_ASSERTIONS_CONTEXT_ARGS)
 {
-    _assert(b == false, CF_ASSERTIONS_CONTEXT, "(%s): is not false", boolToString(b));
+    _assert(b == false, CF_ASSERTIONS_CONTEXT, "(%s): is not false", bool_to_string(b));
 }
 
-int _assertZero(int x, CF_ASSERTIONS_CONTEXT_ARGS)
+int _assert_zero(int x, CF_ASSERTIONS_CONTEXT_ARGS)
 {
     _assert(x == 0, CF_ASSERTIONS_CONTEXT, "(%d): is not zero", x);
 }
-int _assertNonZero(int x, CF_ASSERTIONS_CONTEXT_ARGS)
+int _assert_non_zero(int x, CF_ASSERTIONS_CONTEXT_ARGS)
 {
     _assert(x, CF_ASSERTIONS_CONTEXT, "(0): is zero");
 }
 
-int _assertIntEqual(int x, int y, CF_ASSERTIONS_CONTEXT_ARGS)
+int _assert_int_equal(int x, int y, CF_ASSERTIONS_CONTEXT_ARGS)
 {
     _assert(x == y, CF_ASSERTIONS_CONTEXT, "(%d, %d): are not equal", x, y);
 }
-int _assertIntNotEqual(int x, int y, CF_ASSERTIONS_CONTEXT_ARGS)
+int _assert_int_not_equal(int x, int y, CF_ASSERTIONS_CONTEXT_ARGS)
 {
     _assert(x != y, CF_ASSERTIONS_CONTEXT, "(%d, %d): are equal", x, y);
 }
 
-int _assertIntGe(int x, int y, CF_ASSERTIONS_CONTEXT_ARGS)
+int _assert_int_ge(int x, int y, CF_ASSERTIONS_CONTEXT_ARGS)
 {
     _assert(x >= y, CF_ASSERTIONS_CONTEXT, "(%d, %d): not greater or equal", x, y);
 }
-int _assertIntLe(int x, int y, CF_ASSERTIONS_CONTEXT_ARGS)
+int _assert_int_le(int x, int y, CF_ASSERTIONS_CONTEXT_ARGS)
 {
     _assert(x <= y, CF_ASSERTIONS_CONTEXT, "(%d, %d): not less or equal equal", x, y);
 }
-int _assertIntGreater(int x, int y, CF_ASSERTIONS_CONTEXT_ARGS)
+int _assert_int_greater(int x, int y, CF_ASSERTIONS_CONTEXT_ARGS)
 {
     _assert(x > y, CF_ASSERTIONS_CONTEXT, "(%d, %d): not greater", x, y);
 }
-int _assertIntLess(int x, int y, CF_ASSERTIONS_CONTEXT_ARGS)
+int _assert_int_less(int x, int y, CF_ASSERTIONS_CONTEXT_ARGS)
 {
     _assert(x < y, CF_ASSERTIONS_CONTEXT, "(%d, %d): not less", x, y);
 }
-int _assertIntNonNegative(int x, CF_ASSERTIONS_CONTEXT_ARGS)
+int _assert_int_non_negative(int x, CF_ASSERTIONS_CONTEXT_ARGS)
 {
     _assert(x >= 0, CF_ASSERTIONS_CONTEXT, "(%d): negative", x);
 }
-int _assertIntNonPositive(int x, CF_ASSERTIONS_CONTEXT_ARGS)
+int _assert_int_non_positive(int x, CF_ASSERTIONS_CONTEXT_ARGS)
 {
     _assert(x <= 0, CF_ASSERTIONS_CONTEXT, "(%d): positive", x);
 }
-int _assertIntPositive(int x, CF_ASSERTIONS_CONTEXT_ARGS)
+int _assert_int_nositive(int x, CF_ASSERTIONS_CONTEXT_ARGS)
 {
     _assert(x > 0, CF_ASSERTIONS_CONTEXT, "(%d): negative or zero", x);
 }
-int _assertIntNegative(int x, CF_ASSERTIONS_CONTEXT_ARGS)
+int _assert_int_negative(int x, CF_ASSERTIONS_CONTEXT_ARGS)
 {
     _assert(x < 0, CF_ASSERTIONS_CONTEXT, "(%d): positive or zero", x);
 }
 
-int _assertCharEqual(char c1, char c2, CF_ASSERTIONS_CONTEXT_ARGS)
+int _assert_char_equal(char c1, char c2, CF_ASSERTIONS_CONTEXT_ARGS)
 {
     _assert(c1 == c2, CF_ASSERTIONS_CONTEXT, "(%c, %c): not the same character", c1, c2);
 }
-int _assertCharNotEqual(char c1, char c2, CF_ASSERTIONS_CONTEXT_ARGS)
+int _assert_char_not_equal(char c1, char c2, CF_ASSERTIONS_CONTEXT_ARGS)
 {
     _assert(c1 != c2, CF_ASSERTIONS_CONTEXT, "(%c, %c): are the same character", c1, c2);
 }
 
-int _assertByteEqual(unsigned char b1, unsigned char b2, CF_ASSERTIONS_CONTEXT_ARGS)
+int _assert_byte_equal(unsigned char b1, unsigned char b2, CF_ASSERTIONS_CONTEXT_ARGS)
 {
     _assert(b1 == b2, CF_ASSERTIONS_CONTEXT, "(%d, %d): not the same byte", b1, b2);
 }
-int _assertByteNotEqual(unsigned char b1, unsigned char b2, CF_ASSERTIONS_CONTEXT_ARGS)
+int _assert_byte_not_equal(unsigned char b1, unsigned char b2, CF_ASSERTIONS_CONTEXT_ARGS)
 {
     _assert(b1 != b2, CF_ASSERTIONS_CONTEXT, "(%d, %d): are the same byte", b1, b2);
 }
 
-int _assertStringEqual(const char *s1, const char *s2, CF_ASSERTIONS_CONTEXT_ARGS)
+int _assert_string_equal(const char *s1, const char *s2, CF_ASSERTIONS_CONTEXT_ARGS)
 {
     _assert(strcmp(s1, s2) == 0, CF_ASSERTIONS_CONTEXT, "(%s, %s): are not equal", s1, s2);
 }
-int _assertStringNotEqual(const char *s1, const char *s2, CF_ASSERTIONS_CONTEXT_ARGS)
+int _assert_string_not_equal(const char *s1, const char *s2, CF_ASSERTIONS_CONTEXT_ARGS)
 {
     _assert(strcmp(s1, s2) != 0, CF_ASSERTIONS_CONTEXT, "(\"%s\", \"%s\"): are equal", s1, s2);
 }
 
-static char *boolToString(bool b)
+static char *bool_to_string(bool b)
 {
     static char s[6];
     if (b == false)
@@ -144,12 +144,12 @@ static char *boolToString(bool b)
     return s;
 }
 
-int _assertTrueChain(bool b, _ASSERT_ARGS)
+int _assert_true_chain(bool b, _ASSERT_ARGS)
 {
     _assert(b == true, CF_ASSERTIONS_CONTEXT, " call to function returned false");
 }
 
-int _assertFalseChain(bool b, _ASSERT_ARGS)
+int _assert_false_chain(bool b, _ASSERT_ARGS)
 {
     _assert(b == false, CF_ASSERTIONS_CONTEXT, " call to function returned true");
 }

--- a/src/build.c
+++ b/src/build.c
@@ -2,7 +2,7 @@
 #include <string.h>
 #include <stdio.h>
 
-void _initScope(struct cfScope *s, const char *name)
+void _init_scope(struct cfScope *s, const char *name)
 {
     static const unsigned int NODE_PREFIX_SIZE = 5;
     strcpy(s->name, name + NODE_PREFIX_SIZE);
@@ -13,7 +13,7 @@ void _initScope(struct cfScope *s, const char *name)
     s->assertions = (struct cfTestsCount){0, 0};
 }
 
-void _cfAddChild(struct cfScope *parent, struct cfScope *child)
+void _cf_add_child(struct cfScope *parent, struct cfScope *child)
 {
     struct cfScope *p;
     unsigned int i = 0;

--- a/src/children.c
+++ b/src/children.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include "children.h"
 
-struct cfScope *getParent(struct cfScope *s, unsigned int depth)
+struct cfScope *get_parent(struct cfScope *s, unsigned int depth)
 {
     struct cfScope *p = s;
     for (; p && p->parent && depth; p = p->parent, --depth)
@@ -9,7 +9,7 @@ struct cfScope *getParent(struct cfScope *s, unsigned int depth)
     return p;
 }
 
-int getChildIndex(struct cfScope *s)
+int get_child_index(struct cfScope *s)
 {
     if (s->parent == NULL)
         return -1;
@@ -21,9 +21,9 @@ int getChildIndex(struct cfScope *s)
     return -1;
 }
 
-bool isLastChild(struct cfScope *s)
+bool is_last_child(struct cfScope *s)
 {
-    int index = getChildIndex(s);
+    int index = get_child_index(s);
     if (index == -1)
     {
         fprintf(stderr, "ERROR: Cannot find parent index of node '%s' at %p.\nWARNING: This will probably cause a segmentation fault.\n", s->name, (void *)s);
@@ -32,12 +32,12 @@ bool isLastChild(struct cfScope *s)
     return s->parent->children[index + 1] == NULL;
 }
 
-bool hasChildrenWithErrors(struct cfScope *scope)
+bool has_children_with_errors(struct cfScope *scope)
 {
-    return (countChildrenFailed(scope) != 0);
+    return (count_children_failed(scope) != 0);
 }
 
-unsigned int countChildren(struct cfScope *scope)
+unsigned int count_children(struct cfScope *scope)
 {
     unsigned int c = 0;
     for (unsigned int i = 0; i < CF_MAX_CHILDREN; ++i)
@@ -48,7 +48,7 @@ unsigned int countChildren(struct cfScope *scope)
     return c;
 }
 
-unsigned int countChildrenPassed(struct cfScope *scope)
+unsigned int count_children_passed(struct cfScope *scope)
 {
     unsigned int c = 0;
     for (unsigned int i = 0; i < CF_MAX_CHILDREN; ++i)
@@ -59,7 +59,7 @@ unsigned int countChildrenPassed(struct cfScope *scope)
     return c;
 }
 
-unsigned int countChildrenFailed(struct cfScope *scope)
+unsigned int count_children_failed(struct cfScope *scope)
 {
     unsigned int c = 0;
     for (unsigned int i = 0; i < CF_MAX_CHILDREN; ++i)
@@ -70,7 +70,7 @@ unsigned int countChildrenFailed(struct cfScope *scope)
     return c;
 }
 
-unsigned int countAssertionsPassed(struct cfScope *scope)
+unsigned int count_assertions_passed(struct cfScope *scope)
 {
     unsigned int sum = 0;
     for (unsigned int i = 0; i < CF_MAX_CHILDREN; ++i)
@@ -78,14 +78,14 @@ unsigned int countAssertionsPassed(struct cfScope *scope)
         if (scope->children[i] != NULL)
         {
             sum += scope->children[i]->assertions.passed;
-            if (countChildren(scope->children[i]))
-                sum += countAssertionsPassed(scope->children[i]);
+            if (count_children(scope->children[i]))
+                sum += count_assertions_passed(scope->children[i]);
         }
     }
     return sum;
 }
 
-unsigned int countAssertionsFailed(struct cfScope *scope)
+unsigned int count_assertions_failed(struct cfScope *scope)
 {
     unsigned int sum = 0;
     for (unsigned int i = 0; i < CF_MAX_CHILDREN; ++i)
@@ -93,8 +93,8 @@ unsigned int countAssertionsFailed(struct cfScope *scope)
         if (scope->children[i] != NULL)
         {
             sum += scope->children[i]->assertions.failed;
-            if (countChildren(scope->children[i]))
-                sum += countAssertionsFailed(scope->children[i]);
+            if (count_children(scope->children[i]))
+                sum += count_assertions_failed(scope->children[i]);
         }
     }
     return sum;

--- a/src/print.c
+++ b/src/print.c
@@ -24,69 +24,69 @@ static const char *hbar = "─", *vbar = "│", *branch = "├", *angle = "└",
 static const char *nbsp = " ";
 unsigned int TAB_SIZE = 4;
 
-static void printPadding(const char *head, const char *body);
-static char *getPaddingHead(struct cfScope *s, const unsigned int depth);
-static char *getPaddingBody(const unsigned int depth);
-static char *getScopeHead(struct cfScope *s);
-static void _cfPrintScopeAssertions(struct cfScope *s);
+static void print_padding(const char *head, const char *body);
+static char *get_padding_head(struct cfScope *s, const unsigned int depth);
+static char *get_padding_body(const unsigned int depth);
+static char *get_scope_head(struct cfScope *s);
+static void _cf_print_scope_assertions(struct cfScope *s);
 
-void _cfPrintAssertionFail(const char *file, const char *assertionType, const unsigned int line, const struct cfScope *scope)
+void _cf_print_assertion_fail(const char *file, const char *assertionType, const unsigned int line, const struct cfScope *scope)
 {
     printf("%s%s:%u%s: in function %s: %s", bold, file, line, end, scope->name, assertionType + 1);
 }
 
-int _cfReturnCode(struct cfScope *root)
+int _cf_return_code(struct cfScope *root)
 {
-    if (countAssertionsFailed(root) == 0)
+    if (count_assertions_failed(root) == 0)
     {
         return 0;
     }
     return 1;
 }
 
-int _cfPrintResults(struct cfScope *root)
+int _cf_print_results(struct cfScope *root)
 {
     puts("\nTotal:");
-    unsigned int passed = countAssertionsPassed(root);
-    unsigned int failed = countAssertionsFailed(root);
+    unsigned int passed = count_assertions_passed(root);
+    unsigned int failed = count_assertions_failed(root);
     if (passed)
         printf("%s %u passed main blocks\n%s %u passed assertions\n", checkMark,
-               countChildrenPassed(root), checkMark, passed);
+               count_children_passed(root), checkMark, passed);
     if (failed)
         printf("%s %u failed main blocks\n%s %u failed assertions\n", notCheckMark,
-               countChildrenFailed(root), notCheckMark, failed);
+            count_children_passed(root), notCheckMark, failed);
     if (!failed && !passed)
         fprintf(stderr, "WARNING: scope '%s' has no failed or passed blocks\n",
                 root->name);
     return 0;
 }
 
-void printTree(struct cfScope *s)
+void print_tree(struct cfScope *s)
 {
     if (s->parent != NULL)
         fprintf(stderr, "WARNING: node '%s' at %p has a parent '%s' at %p\n",
                 s->name, (void *)s, s->parent->name, (void *)s->parent);
-    printScope(s, 0);
+    print_scope(s, 0);
 }
 
-void printScope(struct cfScope *s, const int depth)
+void print_scope(struct cfScope *s, const int depth)
 {
     if (s == NULL)
         return;
     for (unsigned int i = depth; i; --i)
     {
-        printPadding(getPaddingHead(s, i), getPaddingBody(i));
+        print_padding(get_padding_head(s, i), get_padding_body(i));
         putc(' ', stdout);
     }
-    printf("%s %s", getScopeHead(s), s->name);
-    _cfPrintScopeAssertions(s);
+    printf("%s %s", get_scope_head(s), s->name);
+    _cf_print_scope_assertions(s);
     for (int i = 0; i < CF_MAX_CHILDREN; ++i)
     {
-        printScope(s->children[i], depth + 1);
+        print_scope(s->children[i], depth + 1);
     }
 }
 
-static void _cfPrintScopeAssertions(struct cfScope *s)
+static void _cf_print_scope_assertions(struct cfScope *s)
 {
     if (!s->assertions.passed && !s->assertions.failed)
     {
@@ -103,7 +103,7 @@ static void _cfPrintScopeAssertions(struct cfScope *s)
     puts(")");
 }
 
-static void printPadding(const char *head, const char *body)
+static void print_padding(const char *head, const char *body)
 {
     fputs(head, stdout);
     for (unsigned int i = 0; i < TAB_SIZE - 2; ++i)
@@ -112,20 +112,20 @@ static void printPadding(const char *head, const char *body)
     }
 }
 
-static char *getScopeHead(struct cfScope *s)
+static char *get_scope_head(struct cfScope *s)
 {
     static char head[13];
-    if (s->assertions.failed || hasChildrenWithErrors(s))
+    if (s->assertions.failed || has_children_with_errors(s))
         strcpy(head, notCheckMark);
     else
         strcpy(head, checkMark);
     return head;
 }
 
-static char *getPaddingHead(struct cfScope *s, const unsigned int depth)
+static char *get_padding_head(struct cfScope *s, const unsigned int depth)
 {
     static char head[4];
-    if (isLastChild(getParent(s, depth - 1)))
+    if (is_last_child(get_parent(s, depth - 1)))
     {
         if (depth == 1)
             strcpy(head, angle);
@@ -142,7 +142,7 @@ static char *getPaddingHead(struct cfScope *s, const unsigned int depth)
     return head;
 }
 
-static char *getPaddingBody(const unsigned int depth)
+static char *get_padding_body(const unsigned int depth)
 {
     static char body[4];
     if (depth == 1)

--- a/test/test.c
+++ b/test/test.c
@@ -6,19 +6,19 @@ void test_return_value(CFTEST);
 
 int main(void)
 {
-    cfInit();
-    cfTest(test_assertions);
-    cfTest(test_return_value);
-    cfPrintCallTree();
-    cfPrintResults();
+    cf_init();
+    cf_test(test_assertions);
+    cf_test(test_return_value);
+    cf_print_call_tree();
+    cf_print_results();
     return 0;
 }
 
 void test_return_value(CFTEST)
 {
-    if (assertTrue(true))
+    if (assert_true(true))
     {
-        assertNull(NULL); // ok, great
+        assert_null(NULL); // ok, great
     }
     /* Works well, but commented because it outputs a failed assertion
     (as expected)

--- a/test/test_assertions.c
+++ b/test/test_assertions.c
@@ -14,93 +14,93 @@ void test_chain_assertions(CFTEST);
 
 void test_assertions(CFTEST)
 {
-    cfTest(test_bool_assertions);
-    cfTest(test_pointers_assertions);
-    cfTest(test_int_assertions);
-    cfTest(test_char_assertions);
-    cfTest(test_byte_assertions);
-    cfTest(test_string_assertions);
-    cfTest(test_chain_assertions);
+    cf_test(test_bool_assertions);
+    cf_test(test_pointers_assertions);
+    cf_test(test_int_assertions);
+    cf_test(test_char_assertions);
+    cf_test(test_byte_assertions);
+    cf_test(test_string_assertions);
+    cf_test(test_chain_assertions);
 }
 
 void test_pointers_assertions(CFTEST)
 {
-    assertNull(NULL);
-    assertNull(0);
+    assert_null(NULL);
+    assert_null(0);
     int a = 3, b = 3;
     int *p = &a;
     int *q = &b;
     int *r = &b;
-    assertNotNull(p);
-    assertNotNull(&p);
+    assert_not_null(p);
+    assert_not_null(&p);
 
-    assertPointerEqual(q, r);
-    assertPointerNotEqual(p, q);
-    assertPointerNotEqual(p, r);
+    assert_pointer_equal(q, r);
+    assert_pointer_not_equal(p, q);
+    assert_pointer_not_equal(p, r);
 }
 
 void test_bool_assertions(CFTEST)
 {
-    assertTrue(true);
-    assertTrue(1);
-    assertTrue(2);
-    assertTrue(-6);
+    assert_true(true);
+    assert_true(1);
+    assert_true(2);
+    assert_true(-6);
 
-    assertFalse(0);
-    assertFalse(false);
+    assert_false(0);
+    assert_false(false);
 }
 
 void test_int_assertions(CFTEST)
 {
-    cfTest(test_int_equal);
-    cfTest(test_int_compare);
+    cf_test(test_int_equal);
+    cf_test(test_int_compare);
 }
 
 void test_int_equal(CFTEST)
 {
-    assertZero(2 - 2);
-    assertNonZero(2 - 3);
-    assertIntEqual(2 + 4, 6);
-    assertIntNotEqual(2 + 4, 5);
+    assert_zero(2 - 2);
+    assert_non_zero(2 - 3);
+    assert_int_equal(2 + 4, 6);
+    assert_int_not_equal(2 + 4, 5);
 }
 
 void test_int_compare(CFTEST)
 {
-    assertIntGe(3, 2);
-    assertIntGe(1, 1);
-    assertIntLe(2, 3);
-    assertIntLe(1, 1);
-    assertIntGreater(3, -2);
-    assertIntLess(-2, 3);
+    assert_int_ge(3, 2);
+    assert_int_ge(1, 1);
+    assert_int_le(2, 3);
+    assert_int_le(1, 1);
+    assert_int_greater(3, -2);
+    assert_int_less(-2, 3);
 }
 
 void test_char_assertions(CFTEST)
 {
     char a = 'a', b = 'b';
-    assertCharEqual(a, a);
-    assertCharEqual(b, b);
-    assertCharNotEqual(a, b);
-    assertCharNotEqual(b, a);
+    assert_char_equal(a, a);
+    assert_char_equal(b, b);
+    assert_char_not_equal(a, b);
+    assert_char_not_equal(b, a);
 }
 
 void test_byte_assertions(CFTEST)
 {
     unsigned char a = 12, b = 34;
-    assertCharEqual(a, a);
-    assertCharEqual(b, b);
-    assertCharNotEqual(a, b);
-    assertCharNotEqual(b, a);
+    assert_char_equal(a, a);
+    assert_char_equal(b, b);
+    assert_char_not_equal(a, b);
+    assert_char_not_equal(b, a);
 }
 
 void test_string_assertions(CFTEST)
 {
-    assertStringEqual("blah", "blah");
-    assertStringEqual("blah" + 1, "lah");
-    assertStringEqual("blah", "blah\0");
+    assert_string_equal("blah", "blah");
+    assert_string_equal("blah" + 1, "lah");
+    assert_string_equal("blah", "blah\0");
 
-    assertStringNotEqual("blah", "bleh");
-    assertStringNotEqual("blah", "lah");
-    assertStringNotEqual("blah", "bla");
+    assert_string_not_equal("blah", "bleh");
+    assert_string_not_equal("blah", "lah");
+    assert_string_not_equal("blah", "bla");
 }
 
 bool is_five(int n)
@@ -110,6 +110,6 @@ bool is_five(int n)
 
 void test_chain_assertions(CFTEST)
 {
-    assertChain(is_five, 5);
-    assertChainNot(is_five, 4);
+    assert_chain(is_five, 5);
+    assert_chain_not(is_five, 4);
 }


### PR DESCRIPTION
Fixes #5. Creating a `conferCaml.h` file was not deemed necessary for now, might be a future inclusion but this is enough for a PR.